### PR TITLE
Set MAC address in qemu to support provisioning

### DIFF
--- a/scripts/run-qemu
+++ b/scripts/run-qemu
@@ -22,5 +22,5 @@ sudo qemu-system-x86_64  \
 	-show-cursor \
 	-vga std \
 	-net user,hostfwd=tcp:127.0.0.1:2222-:22 \
-	-net nic \
+	-net nic,macaddr=52:54:00:12:31:68 \
 	-cpu Haswell -enable-kvm


### PR DESCRIPTION
This uses a pre-configured MAC address that is known to ota-plus-demo-provision

Fixes: PRO-723
