### PR TITLE
CES2016-demo: Launch CES2016 home app at startup

### DIFF
--- a/recipes-demo-hmi/CES2016-demo/CES2016-demo.bbappend
+++ b/recipes-demo-hmi/CES2016-demo/CES2016-demo.bbappend
@@ -1,2 +1,28 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI += "file://change-resolution.patch"
+
+inherit systemd
+
+do_install_append() {
+ if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)} && ${@bb.utils.contains('DISTRO_FEATURES', 'ota-plus-apps', 'true', 'false', d)}; then
+  # Execute these manually on behalf of systemctl script (from systemd-systemctl-native.bb)
+  # to deploy demohmi systemd service because it does not support systemd's user mode.
+  install -m 644 -p -D ${S}/scripts/demohmi.service ${D}${systemd_user_unitdir}/demohmi.service
+  mkdir -p ${D}/${ROOT_HOME}/.config/systemd/user/default.target.wants/
+  ln -sf ${systemd_user_unitdir}/demohmi.service ${D}/${ROOT_HOME}/.config/systemd/user/default.target.wants/demohmi.service
+ fi
+}
+
+pkg_postinst_${PN} () {
+#!/bin/sh -e
+# Swith to Weston IVI shell
+mv /etc/xdg/weston/weston.ini /etc/xdg/weston/weston.ini.desktop-shell
+cp /opt/AGL/CES2016/weston.ini.ivi-shell /etc/xdg/weston/
+ln -sf /etc/xdg/weston/weston.ini.ivi-shell /etc/xdg/weston/weston.ini
+}
+
+FILES_${PN} += " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'ota-plus-apps', '${systemd_user_unitdir}/demohmi.service', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'ota-plus-apps', '${ROOT_HOME}/.config/systemd/user/default.target.wants/', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'ota-plus-apps', '${ROOT_HOME}/.config/systemd/user/default.target.wants/demohmi.service', '', d)} \
+    "


### PR DESCRIPTION
Enable demohmi systemd service and automatically
launch CES2016 home application at startup if
feature ota-plus-apps is enabled for the
distribution.

Signed-off-by: Leon Anavi leon.anavi@konsulko.com
