### PR TITLE
Rebuild ota-plus-demo-provision on git changes

### DIFF
--- a/recipes-provision/ota-plus-demo-provision/ota-plus-demo-provision.bb
+++ b/recipes-provision/ota-plus-demo-provision/ota-plus-demo-provision.bb
@@ -8,6 +8,8 @@ S = "${WORKDIR}/git"
 
 SRCREV = "${AUTOREV}"
 
+PV = "1.0+${SRCPV}"
+
 inherit systemd
 
 PR="4"


### PR DESCRIPTION
Bitbake won't rebuild the package unless PV depends on SRCPV (which depends on
the git commit hash of HEAD).
