### PR TITLE
Add a pair of minimal images for testing

### DIFF
--- a/recipes-platform/images/minimal-image-1.bb
+++ b/recipes-platform/images/minimal-image-1.bb
@@ -1,0 +1,17 @@
+DESCRIPTION = "Minimal OTA-Plus image"
+
+IMAGE_ROOTFS_SIZE ?= "8192"
+
+# 1GB of extra space
+IMAGE_ROOTFS_EXTRA_SPACE = "1000000"
+
+IMAGE_FEATURES += "splash package-management ssh-server-dropbear"
+
+inherit core-image
+
+IMAGE_INSTALL_append = " \
+    connman \
+    connman-tools \
+    connman-client \
+    packagegroup-agl-sota \
+    "

--- a/recipes-platform/images/minimal-image-2.bb
+++ b/recipes-platform/images/minimal-image-2.bb
@@ -1,0 +1,6 @@
+include minimal-image-1.bb
+
+DESCRIPTION = "Minimal OTA-Plus image - with man"
+
+
+IMAGE_INSTALL_append = " man "


### PR DESCRIPTION
These are 100MB in size vs 150MB for the AGL image, but ostree can process them
at least 10x faster. I don't know why this is.
