### PR TITLE
Disable bsdiff to improve generating performance

### DIFF
--- a/scripts/ostree_image.py
+++ b/scripts/ostree_image.py
@@ -199,7 +199,7 @@ def main():
     if not args.small:
         # generate static delta
         cmd = ["ostree", "--repo="+args.repo, "static-delta", "generate",
-               '--to='+to, "--inline", "--min-fallback-size=65536"]
+               '--to='+to, "--inline", "--min-fallback-size=65536", "--disable-bsdiff"]
 
         if delta_from:
             cmd.append('--from='+delta_from)


### PR DESCRIPTION
Probably it makes sense to disable bsdiff. Makes deltas a bit larger but significantly reduces build time.
